### PR TITLE
Stake and Recoup Stake functions now taking into account the paused contract

### DIFF
--- a/contracts/ETHDenverStaking.sol
+++ b/contracts/ETHDenverStaking.sol
@@ -42,7 +42,7 @@ contract ETHDenverStaking is Ownable, Pausable {
     // Public functions
 
     // function allow the staking for a participant
-    function stake(address _userUportAddress, uint _expiryDate, bytes _signature) public payable {
+    function stake(address _userUportAddress, uint _expiryDate, bytes _signature) public payable whenNotPaused {
         bytes32 hashMessage = keccak256(abi.encodePacked(_userUportAddress, msg.value, _expiryDate));
         address signer = hashMessage.toEthSignedMessageHash().recover(_signature);
 
@@ -57,7 +57,7 @@ contract ETHDenverStaking is Ownable, Pausable {
     }
 
     // function allow the staking for a participant
-    function recoupStake(address _userUportAddress, uint _expiryDate, bytes _signature) public {
+    function recoupStake(address _userUportAddress, uint _expiryDate, bytes _signature) public whenNotPaused {
         bytes32 hashMessage = keccak256(abi.encodePacked(_userUportAddress, _expiryDate));
         address signer = hashMessage.toEthSignedMessageHash().recover(_signature);
 

--- a/test/TestETHDenverStaking.js
+++ b/test/TestETHDenverStaking.js
@@ -193,8 +193,37 @@ contract("ETHDenverStaking", async function (accounts) {
         it("without being an owner fails", async function () {
             await assertRevert(this.contract.setGrantSigner(changedSigner, { from: sender }));
         });
+    });
 
+    describe('ETHDenverStaking - pausable', () => {
 
+        it("stake fails when paused", async function () {
+            await this.contract.pause({ from: owner });
+            await assertRevert(this.contract.stake(userAddress, this.grant.expiringDate, this.grant.signature, { from: staker, value: this.grant.amountStake }));
+        });
+
+        it("recoup stake fails when paused", async function () {
+            const recoupGrant = generateRecoupStakeGrant(signer, userAddress);
+            await this.contract.stake(userAddress, this.grant.expiringDate, this.grant.signature, { from: staker, value: this.grant.amountStake });
+            await this.contract.pause({ from: owner });
+            await assertRevert(this.contract.recoupStake(userAddress, recoupGrant.expiringDate, recoupGrant.signature, { from: staker }));
+        });
+
+        it("stake success when unpaused", async function () {
+            await this.contract.pause({ from: owner });
+            await assertRevert(this.contract.stake(userAddress, this.grant.expiringDate, this.grant.signature, { from: staker, value: this.grant.amountStake }));
+            await this.contract.unpause({ from: owner });
+            await this.contract.stake(userAddress, this.grant.expiringDate, this.grant.signature, { from: staker, value: this.grant.amountStake });
+        });
+
+        it("recoup stake success when unpaused", async function () {
+            const recoupGrant = generateRecoupStakeGrant(signer, userAddress);
+            await this.contract.stake(userAddress, this.grant.expiringDate, this.grant.signature, { from: staker, value: this.grant.amountStake });
+            await this.contract.pause({ from: owner });
+            await assertRevert(this.contract.recoupStake(userAddress, recoupGrant.expiringDate, recoupGrant.signature, { from: staker }));
+            await this.contract.unpause({ from: owner });
+            await this.contract.recoupStake(userAddress, recoupGrant.expiringDate, recoupGrant.signature, { from: staker });
+        });
     });
 });
 


### PR DESCRIPTION
 ETHDenverStaking - pausable
      ✓ stake fails when paused (58ms)
      ✓ recoup stake fails when paused (215ms)
      ✓ stake success when unpaused (109ms)
      ✓ recoup stake success when unpaused (276ms)