### PR TITLE
Allow restaking. 

### DIFF
--- a/contracts/ETHDenverStaking.sol
+++ b/contracts/ETHDenverStaking.sol
@@ -67,6 +67,7 @@ contract ETHDenverStaking is Ownable, Pausable {
 
         address stakedBy = userStakedAddress[_userUportAddress];
         uint256 amount = stakedAmount[_userUportAddress];
+        userStakedAddress[_userUportAddress] = address(0x0);
         stakedAmount[_userUportAddress] = 0;
 
         stakedBy.transfer(amount);

--- a/contracts_flat/ETHDenverStaking_flat.sol
+++ b/contracts_flat/ETHDenverStaking_flat.sol
@@ -304,6 +304,7 @@ contract ETHDenverStaking is Ownable, Pausable {
 
         address stakedBy = userStakedAddress[_userUportAddress];
         uint256 amount = stakedAmount[_userUportAddress];
+        userStakedAddress[_userUportAddress] = address(0x0);
         stakedAmount[_userUportAddress] = 0;
 
         stakedBy.transfer(amount);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
   },
   "homepage": "https://github.com/joaoaguiam/ethdenver-staking-contracts#readme",
   "dependencies": {
+    "truffle": "4.1.14",
     "truffle-hdwallet-provider": "0.0.6",
     "zeppelin-solidity": "^1.12.0"
+  },
+  "devDependencies": {
+    "node-gyp": "^3.8.0"
   }
 }


### PR DESCRIPTION
This will be useful if we need to manually wipe a person from the DB, and allow them to start fresh.

The application can enforce that only one stake -> recoup cycle is allowed. But it's nice if the contract has the flexibility to allow more than one cycle. 

This was an issue I ran into when testing the application tonight, and I deleted my profile entry on firebase, and created a new account and tried to stake again on my new account.